### PR TITLE
Better errors and reduced compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-recursion"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "fae"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "async-recursion",
  "dashmap",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,11 +415,9 @@ checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.132", features = ["derive"] }
 toml = "0.5.8"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process"] }
 futures = "0.3.19"
 async-recursion = "0.3.2"
 dashmap = "5.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ async-recursion = "0.3.2"
 dashmap = "5.0.0"
 serde_json = "1.0.73"
 which = "4.2.2"
+
+# Terminal output coloring
+ansi_term = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use std::{env, fs};
 use tokio::process::Command;
 use toml;
 
+mod out;
+
 #[derive(Deserialize, Debug)]
 struct CommandConfig {
     uses: Option<Vec<String>>,
@@ -155,10 +157,24 @@ async fn run_script(
 
 #[tokio::main]
 async fn main() {
+    // Before we do anything, we want to change how the panic message will look
+    // so they are more user friendly
+    out::change_panic_message();
+
     let args: Vec<String> = env::args().collect();
-    let script = &args
-        .get(1)
-        .expect(format!("Usage: {} <script>", args[0]).as_str());
+    let script = &args.get(1);
+
+    if script.is_none() {
+        // TODO: Get the program version here somehow
+        println!("Fae nightly");
+        println!("Usage: {} <script>", args[0]);
+
+        return;
+    }
+
+    // We have already caught the case where not enough args are passed in, so
+    // this is safe
+    let script = script.unwrap();
 
     let mut env_overrides = HashMap::new();
     let mut config = HashMap::new();

--- a/src/out.rs
+++ b/src/out.rs
@@ -1,0 +1,24 @@
+use ansi_term::Colour::{Fixed, Red, Yellow};
+use std::panic::{set_hook, PanicInfo};
+
+pub fn warning(message: &str) {
+    println!("{} {}", Yellow.paint("WARNING"), message);
+}
+
+fn panic_message(info: &PanicInfo) {
+    if let Some(message) = info.payload().downcast_ref::<String>() {
+        println!("{} something caused a panic within fae", Red.paint("ERROR"));
+        println!("    {}", Fixed(248).paint(message));
+    } else {
+        warning("Oops, we couldn't format the panic properly, here is what it says");
+        panic!("{:?}", info.payload());
+    }
+}
+
+/// Registers a new function that is responsible for handling panic messages.
+/// This is based off the information provided in the stack overflow post:
+///
+/// https://stackoverflow.com/questions/51786498/is-there-a-way-to-make-expect-output-a-more-user-friendly-message
+pub fn change_panic_message() {
+    set_hook(Box::new(panic_message));
+}


### PR DESCRIPTION
## Better errors
Panics are now formatted in a way that is slightly more readable:

![image](https://user-images.githubusercontent.com/23250792/147539808-f1c071e9-2044-4863-9f1b-bf5c4b70f008.png)

This fixes #1 

## Improved performance
I have stripped back the number of dependencies required by `tokio`, dropping 8 seconds off the build time:

| Origin       | User | System | CPU% | **Total Time** | 
| -- | -- | -- | -- | -- |
| Upstream | 83.4s| 4.4s      | 234%  | 37.5s     |
| Patch       | 73.6s| 4.5s      | 265%  | 29.4s      | 