### PR TITLE
Primitive correction recommender 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+fae.toml

--- a/src/autocorrection.rs
+++ b/src/autocorrection.rs
@@ -1,0 +1,38 @@
+//! Implements autocorrection / recommendations for the fae.toml file
+
+use crate::out;
+
+fn remove_whitespace(s: &str) -> String {
+    s.split_whitespace().collect()
+}
+
+/// Hacky method for checking if a field exists. It will remove all the
+/// whitespace and then check if '{field_name}=' is present. Should work mostly
+/// fine
+fn field_exists(config: &str, field_name: &str) -> bool {
+    remove_whitespace(config).contains(&format!("{}=", field_name))
+}
+
+/// Checks if an incorrect field is present using `field_exists` and provides a
+/// console warning to the user
+fn correct(config: &str, replacement: &str, field_names: Vec<&str>) {
+    for field_name in field_names {
+        if field_exists(config, field_name) {
+            out::warning(&format!(
+                "Fae doesn't support the field '{}'. You might want to use the field '{}' instead",
+                field_name, replacement
+            ));
+        }
+    }
+}
+
+/// Where we check everything to keep code complexity out of the main.rs file
+pub fn run(config: &str) {
+    correct(
+        config,
+        "uses",
+        vec!["use", "needs", "dependencies", "before", "depends"],
+    );
+
+    correct(config, "run", vec!["command", "cmd", "script"]);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::{env, fs};
 use tokio::process::Command;
 use toml;
 
+mod autocorrection;
 mod out;
 
 #[derive(Deserialize, Debug)]
@@ -228,6 +229,10 @@ async fn main() {
         let fae: HashMap<String, CommandConfig> = toml::from_str(&content)
             .expect("Could not parse config file, make sure that it is valid TOML");
         config.extend(fae);
+
+        // To provide better user experience, we want to provide something like
+        // autocorrection if a user gets a field name somewhat wrong
+        autocorrection::run(&content);
     }
 
     let mut script_args = env::args();


### PR DESCRIPTION
## Context
I am currently using fae in one of my testing projects and I ran into an issue, where I couldn't remember what keyword is used for adding a dependency so I just used `needs` and got no feedback. This pull request implements a primitive form of corrections that would have caught this and recommended me to use the `use` field. 

## Example
Given the following config:
```toml
[a]
cmd = "echo 'a'"

[test]
needs = ["a"]
script = "echo 'test'"
```

The the following would be logged to the console:
```
WARNING Fae doesn't support the field 'needs'. You might want to use the field 'uses' instead
WARNING Fae doesn't support the field 'cmd'. You might want to use the field 'run' instead
WARNING Fae doesn't support the field 'script'. You might want to use the field 'run' instead
```

## Other small changes
`fae.toml` has been added to the gitignore so I can use it as a test file without worrying about committing it. 